### PR TITLE
Add Dwell to Parcel Data

### DIFF
--- a/lib/classes/Region.ts
+++ b/lib/classes/Region.ts
@@ -630,6 +630,7 @@ export class Region
         parcel.ClaimDate = parcelProperties.ClaimDate;
         parcel.ClaimPrice = parcelProperties.ClaimPrice;
         parcel.Desc = parcelProperties.Desc;
+        parcel.Dwell = dwellReply.Data.Dwell;
         parcel.GroupAVSounds = parcelProperties.GroupAVSounds;
         parcel.GroupID = parcelProperties.GroupID;
         parcel.GroupPrims = parcelProperties.GroupPrims;


### PR DESCRIPTION
Currently parcel data does not include Dwell. With this it will. (Dwell is the parcel traffic score)