### PR TITLE
Use LSL Inventory type when uploading scripts. 

### DIFF
--- a/examples/Inventory/Inventory.ts
+++ b/examples/Inventory/Inventory.ts
@@ -24,6 +24,7 @@ class Inventory extends ExampleBot
 
         const exampleFolderName = 'node-metaverse example';
         const exampleNotecardName = 'Example Notecard';
+        const exampleScriptName = 'Example script';
 
         let exampleFolder: InventoryFolder | undefined = undefined;
         for (const childFolder of rootFolder.folders)
@@ -65,6 +66,20 @@ class Inventory extends ExampleBot
 
         exampleNotecard.permissions.nextOwnerMask = PermissionMask.Transfer | PermissionMask.Modify;
         await exampleNotecard.update();
+
+        let exampleScript = exampleFolder.items.find(f => f.name === exampleScriptName);
+        if (exampleScript === undefined){
+            exampleScript = await exampleFolder.uploadAsset(
+                AssetType.LSLText,
+                InventoryType.LSL,
+                Buffer.from(
+                    'default { touch_start(integer total_number) {  llSay(0, "Hello, world!"); } } '
+                  , 'utf-8'
+                ),
+                'Script',
+                ''
+              );
+        }
 
         // Give the notecard to our owner
         await this.bot.clientCommands.comms.giveInventory(this.masterAvatar, exampleNotecard);

--- a/lib/classes/InventoryFolder.ts
+++ b/lib/classes/InventoryFolder.ts
@@ -589,6 +589,7 @@ export class InventoryFolder
                         break;
                     }
                     case InventoryType.Script:
+                    case InventoryType.LSL:
                     {
                         this.agent.currentRegion.caps.capsPostXML('UpdateScriptAgent', {
                             'item_id': new LLSD.UUID(createInventoryMsg.InventoryData[0].ItemID.toString()),
@@ -673,6 +674,7 @@ export class InventoryFolder
                 case InventoryType.Notecard:
                 case InventoryType.Gesture:
                 case InventoryType.Script:
+                case InventoryType.LSL:
                     // These types must be created first and then modified
                     this.uploadInventoryItem(type, inventoryType, data, name, description).then((invItemID: UUID) =>
                     {

--- a/lib/classes/InventoryItem.ts
+++ b/lib/classes/InventoryItem.ts
@@ -238,6 +238,9 @@ export class InventoryItem
                         case 'script':
                             item.inventoryType = InventoryType.Script;
                             break;
+                        case  'LSL':
+                            item.inventoryType = InventoryType.LSL;
+                            break;
                         case 'snapshot':
                             item.inventoryType = InventoryType.Snapshot;
                             break;

--- a/lib/classes/Utils.ts
+++ b/lib/classes/Utils.ts
@@ -174,6 +174,8 @@ export class Utils
                 return 'gesture';
             case InventoryType.Mesh:
                 return 'mesh';
+            case InventoryType.LSL:
+                return 'LSL';
             default:
                 console.error('Unknown inventory type: ' + InventoryType[type]);
                 return 'texture';


### PR DESCRIPTION
Oddly, when creating a script in the user inventory using `InventoryType.Script`, SL server returns `invalid inventory type: "" must be in: ['script']`

I checked on Catznip code and libopenmetaverse, they use `InventoryType.LSL` type (10). I am allowing this to be used in node-metaverse in order to create scripts in the user inventory.