### PR TITLE
Add client commands for Sitting and Standing

### DIFF
--- a/lib/classes/Agent.ts
+++ b/lib/classes/Agent.ts
@@ -370,4 +370,14 @@ export class Agent
         this.appearanceComplete = true;
         this.appearanceCompleteEvent.next();
     }
+
+    setControlFlag(flag: ControlFlags): void
+    {
+        this.controlFlags = this.controlFlags | flag;
+    }
+
+    clearControlFlag(flag: ControlFlags): void
+    {
+        this.controlFlags = this.controlFlags & ~flag;
+    }
 }

--- a/lib/classes/ClientCommands.ts
+++ b/lib/classes/ClientCommands.ts
@@ -12,6 +12,7 @@ import { GroupCommands } from './commands/GroupCommands';
 import { InventoryCommands } from './commands/InventoryCommands';
 import { ParcelCommands } from './commands/ParcelCommands';
 import { FriendCommands } from './commands/FriendCommands';
+import { MovementCommands } from './commands/MovementCommands';
 
 export class ClientCommands
 {
@@ -26,6 +27,7 @@ export class ClientCommands
     public agent: AgentCommands;
     public group: GroupCommands;
     public inventory: InventoryCommands;
+    public movement: MovementCommands;
 
     constructor(region: Region, agent: Agent, bot: Bot)
     {
@@ -40,6 +42,7 @@ export class ClientCommands
         this.agent = new AgentCommands(region, agent, bot);
         this.group = new GroupCommands(region, agent, bot);
         this.inventory = new InventoryCommands(region, agent, bot);
+        this.movement = new MovementCommands(region, agent, bot);
     }
 
     shutdown(): void

--- a/lib/classes/commands/MovementCommands.ts
+++ b/lib/classes/commands/MovementCommands.ts
@@ -1,0 +1,56 @@
+import { ControlFlags, PacketFlags } from "../..";
+import { AgentRequestSitMessage, AgentSitMessage } from "../MessageClasses";
+import { UUID } from "../UUID";
+import { Vector3 } from "../Vector3";
+import { CommandsBase } from "./CommandsBase";
+
+export class MovementCommands extends CommandsBase {
+
+    async sitOnObject(targetID: UUID, offset: Vector3): Promise<void>
+    {
+        await this.requestSitOnObject(targetID, offset);
+        await this.sitOn();
+    }
+
+    sitOnGround(): void
+    {
+        this.agent.setControlFlag(ControlFlags.AGENT_CONTROL_SIT_ON_GROUND);
+        this.agent.sendAgentUpdate();
+    }
+
+    stand(): void
+    {
+        this.agent.clearControlFlag(ControlFlags.AGENT_CONTROL_SIT_ON_GROUND);
+        this.agent.setControlFlag(ControlFlags.AGENT_CONTROL_STAND_UP);
+        this.agent.sendAgentUpdate();
+        this.agent.clearControlFlag(ControlFlags.AGENT_CONTROL_STAND_UP);
+        this.agent.sendAgentUpdate();
+    }
+
+    private async requestSitOnObject(targetID: UUID, offset: Vector3): Promise<void>
+    {
+        const msg = new AgentRequestSitMessage();
+        msg.AgentData = {
+            AgentID: this.agent.agentID,
+            SessionID: this.circuit.sessionID,
+        };
+        msg.TargetObject = {
+            TargetID: targetID,
+            Offset: offset,
+        };
+
+        const seqID = this.circuit.sendMessage(msg, PacketFlags.Reliable);
+        return this.circuit.waitForAck(seqID, 10000);
+    }
+
+    private async sitOn(): Promise<void>
+    {
+        const msg = new AgentSitMessage();
+        msg.AgentData = {
+            AgentID: this.agent.agentID,
+            SessionID: this.circuit.sessionID,
+        };
+        const seqID = this.circuit.sendMessage(msg, PacketFlags.Reliable);
+        return this.circuit.waitForAck(seqID, 10000);
+    }
+}


### PR DESCRIPTION
This adds a new set of commands to `ClientCommands`

`sitOnObject` - takes an object's uuid and an offset vector
`sitOnGround`
`stand`

They have been tested in my own project, but no tests have been written, as I am unsure about the testing setup for this project.

2 functions were added to the `Agent` class to make the setting of bitwise flags clearer to read.

I do vaguely plan to expand on these, but as all I needed was sitting and standing up for now, so I put in a PR before I never get round to doing any of it.