### PR TITLE
Allow use of prehashed passwords with provided Bot class

### DIFF
--- a/lib/LoginHandler.ts
+++ b/lib/LoginHandler.ts
@@ -1,5 +1,4 @@
 import * as xmlrpc from 'xmlrpc';
-import * as crypto from 'crypto';
 import * as uuid from 'uuid';
 import * as url from 'url';
 import { LoginParameters } from './classes/LoginParameters';
@@ -67,7 +66,7 @@ export class LoginHandler
                     {
                         'first': params.firstName,
                         'last': params.lastName,
-                        'passwd': '$1$' + crypto.createHash('md5').update(params.password.substr(0, 16)).digest('hex'),
+                        'passwd': params.getHashedPassword(),
                         'start': params.start,
                         'major': '0',
                         'minor': '0',

--- a/lib/classes/LoginParameters.ts
+++ b/lib/classes/LoginParameters.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'crypto';
+
 export class LoginParameters
 {
     firstName: string;
@@ -5,4 +7,13 @@ export class LoginParameters
     password: string;
     start = 'last';
     url = 'https://login.agni.lindenlab.com/cgi-bin/login.cgi';
+
+    passwordPrehashed = false;
+
+    getHashedPassword() : string {
+        if(this.passwordPrehashed){
+            return this.password;
+        }
+        return '$1$' + crypto.createHash('md5').update(this.password.substr(0, 16)).digest('hex');
+    }
 }


### PR DESCRIPTION
This change allows a pre hashed password to be used for logging in using the provided Bot class.

It makes the `LoginParams` object responsible for hashing the password, instead of an inline hash in the `LoginHandler` and adds a flag to skip hashing if the provided password was pre hashed.

I personally wanted this for my project after a user said they would prefer to send a hashed password through my service if possible, and decided others may like the concept as well.

As it's just MD5 it's not some superb security, but it would make storing passwords for  automatic login processes ever so slightly more palatable.